### PR TITLE
sony: common: sepolicy: Fix tad denials

### DIFF
--- a/sepolicy/tad.te
+++ b/sepolicy/tad.te
@@ -1,11 +1,11 @@
 type tad, domain;
-permissive tad;
 type tad_exec, exec_type, file_type;
+typeattribute tad tad_placeholder;
 
 # Started by init
 init_daemon_domain(tad)
 
 # Allow tad to work it's magic
-allow tad block_device:dir search;
-allow tad block_device:blk_file { ioctl };
+allow tad block_device:dir create_dir_perms;
+allow tad block_device:blk_file rw_file_perms;
 allow tad trim_area_partition_device:blk_file rw_file_perms;


### PR DESCRIPTION
It requires external/sepolicy changes.
Add tad as a sepolicy attribute and fix all permissions.

Signed-off-by: Humberto Borba <humberos@gmail.com>
Change-Id: I991b66671bc8d2bec4df3f4a69df75ad02c46318