### PR TITLE
Disable ADBoverWiFi by default

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -161,10 +161,6 @@ PRODUCT_PROPERTY_OVERRIDES += \
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.data.qmi.adb_logmask=0
 
-# ADBoverWIFI
-PRODUCT_PROPERTY_OVERRIDES += \
-    service.adb.tcp.port=5555
-
 # Enable MultiWindow
 PRODUCT_PROPERTY_OVERRIDES += \
     persist.sys.debug.multi_window=true


### PR DESCRIPTION
Still can enable in developer option , This change just make it so that it won't persist over reboot.